### PR TITLE
15 ajustar remoção de paciente

### DIFF
--- a/src/main/java/com/devluizfcneto/sistemaodontologico/entities/Paciente.java
+++ b/src/main/java/com/devluizfcneto/sistemaodontologico/entities/Paciente.java
@@ -28,7 +28,8 @@ public class Paciente {
 	
 	@Column(name = "data_nascimento")
 	private LocalDate dataNascimento;
-	
+
+//	@OneToMany(mappedBy = "paciente", cascade = CascadeType.ALL, orphanRemoval = true)
 	@OneToMany(mappedBy = "paciente")
 	@JsonManagedReference
 	private List<Consulta> consultas;

--- a/src/main/java/com/devluizfcneto/sistemaodontologico/repositories/PacienteRepository.java
+++ b/src/main/java/com/devluizfcneto/sistemaodontologico/repositories/PacienteRepository.java
@@ -3,11 +3,13 @@ package com.devluizfcneto.sistemaodontologico.repositories;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.devluizfcneto.sistemaodontologico.entities.Paciente;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PacienteRepository extends JpaRepository<Paciente, Long> {
@@ -17,4 +19,7 @@ public interface PacienteRepository extends JpaRepository<Paciente, Long> {
 
 	@Query("SELECT p FROM Paciente p LEFT JOIN FETCH p.consultas c WHERE c.data >= CURRENT_DATE OR c IS NULL")
 	List<Paciente> listPacientesComConsultasFuturas(Sort sort);
+
+	@Query("SELECT p FROM Paciente p LEFT JOIN FETCH p.consultas WHERE p.id = :id")
+	Optional<Paciente> findByIdWithConsultas(@Param("id") Long id);
 }

--- a/src/main/java/com/devluizfcneto/sistemaodontologico/services/impl/ConsultaServiceImpl.java
+++ b/src/main/java/com/devluizfcneto/sistemaodontologico/services/impl/ConsultaServiceImpl.java
@@ -24,6 +24,7 @@ import com.devluizfcneto.sistemaodontologico.services.ConsultaService;
 import com.devluizfcneto.sistemaodontologico.services.PacienteService;
 import com.devluizfcneto.sistemaodontologico.utils.TimeUtils;
 import com.devluizfcneto.sistemaodontologico.validations.CadastrarConsultaValidation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ConsultaServiceImpl implements ConsultaService{
@@ -41,6 +42,7 @@ public class ConsultaServiceImpl implements ConsultaService{
 	private ListarConsultaParamsValidation listarConsultaParamsValidation;
 	
 	@Override
+	@Transactional
 	public ConsultaResponseDTO cadastrar(CadastrarConsultaDTO consultaDTO) {
 		this.cadastrarConsultaValidation.validateCadastrarConsulta(consultaDTO);
 		
@@ -58,7 +60,8 @@ public class ConsultaServiceImpl implements ConsultaService{
 		return new ConsultaResponseDTO(this.consultaRepository.save(novaConsulta));
 
 	}
-	
+
+	@Transactional(readOnly = true)
 	public Boolean checaPacientePossuiConsultaFutura(Paciente paciente, LocalDate now) {
 		Boolean pacientePossuiConsultaFutura = this.consultaRepository.existeConsultaFutura(paciente.getId(), now);
 		if(pacientePossuiConsultaFutura) {
@@ -66,7 +69,8 @@ public class ConsultaServiceImpl implements ConsultaService{
 		}
 		return pacientePossuiConsultaFutura;
 	}
-	
+
+	@Transactional(readOnly = true)
 	public void checaColisaoConsulta(LocalDate dataConsulta, LocalTime horaInicial, LocalTime horaFinal){
 		List<Consulta> consultasColididas = this.consultaRepository.findConflitosHorario(dataConsulta, horaInicial, horaFinal);
 		if(!consultasColididas.isEmpty()) {
@@ -81,11 +85,13 @@ public class ConsultaServiceImpl implements ConsultaService{
 	}
 
 	@Override
+	@Transactional
 	public void remover(Long id) {
 		this.consultaRepository.deleteById(id);
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public List<ConsultaResponseDTO> listarConsultas(String dataInicial, String dataFinal, String direction) {
 		this.listarConsultaParamsValidation.validate(dataInicial, dataFinal);
 		LocalDate dataInicio = dataInicial != null ? DateUtils.formatStringToLocalDate(dataInicial) : null;

--- a/src/test/java/com/devluizfcneto/sistemaodontologico/paciente/PacienteServiceListarTest.java
+++ b/src/test/java/com/devluizfcneto/sistemaodontologico/paciente/PacienteServiceListarTest.java
@@ -1,4 +1,116 @@
 package com.devluizfcneto.sistemaodontologico.paciente;
 
+import com.devluizfcneto.sistemaodontologico.entities.Paciente;
+import com.devluizfcneto.sistemaodontologico.repositories.PacienteRepository;
+import com.devluizfcneto.sistemaodontologico.services.impl.PacienteServiceImpl;
+import com.devluizfcneto.sistemaodontologico.validations.ListarPacienteParamsValidation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
 public class PacienteServiceListarTest {
+    @Mock
+    private PacienteRepository pacienteRepository;
+
+    @Mock
+    private ListarPacienteParamsValidation listarPacienteParamsValidation;
+
+    @InjectMocks
+    private PacienteServiceImpl pacienteService;
+
+    @Test
+    @DisplayName("Deve listar pacientes sem ordenação")
+    void deveListarPacientesSemOrdenacao() {
+        List<Paciente> pacientes = Arrays.asList(
+                new Paciente(1L, "12345678901", "Paciente 1", null),
+                new Paciente(2L, "98765432109", "Paciente 2", null)
+        );
+        when(pacienteRepository.listPacientesComConsultasFuturas(Sort.unsorted())).thenReturn(pacientes);
+
+        List<Paciente> result = pacienteService.listarPacientes(null, null);
+
+        assertEquals(pacientes.size(), result.size());
+        assertEquals(pacientes.get(0).getNome(), result.get(0).getNome());
+        assertEquals(pacientes.get(1).getNome(), result.get(1).getNome());
+
+        verify(listarPacienteParamsValidation, times(1)).validateParameters(null);
+        verify(pacienteRepository, times(1)).listPacientesComConsultasFuturas(Sort.unsorted());
+    }
+
+    @Test
+    @DisplayName("Deve listar pacientes ordenados por nome em ordem crescente")
+    void deveListarPacientesOrdenadosPorNomeAscendente() {
+        String orderBy = "nome";
+        String direction = "asc";
+        Sort sort = Sort.by(Sort.Direction.ASC, orderBy);
+
+        List<Paciente> pacientes = Arrays.asList(
+                new Paciente(1L, "12345678901", "Paciente 1", null),
+                new Paciente(2L, "98765432109", "Paciente 2", null)
+        );
+        when(pacienteRepository.listPacientesComConsultasFuturas(sort)).thenReturn(pacientes);
+
+        List<Paciente> result = pacienteService.listarPacientes(orderBy, direction);
+
+        assertEquals(pacientes.size(), result.size());
+        assertEquals(pacientes.get(0).getNome(), result.get(0).getNome());
+        assertEquals(pacientes.get(1).getNome(), result.get(1).getNome());
+
+        verify(listarPacienteParamsValidation, times(1)).validateParameters(orderBy);
+        verify(pacienteRepository, times(1)).listPacientesComConsultasFuturas(sort);
+    }
+
+    @Test
+    @DisplayName("Deve listar pacientes ordenados por nome em ordem decrescente")
+    void deveListarPacientesOrdenadosPorNomeDescendente() {
+        String orderBy = "nome";
+        String direction = "desc";
+        Sort sort = Sort.by(Sort.Direction.DESC, orderBy);
+
+        List<Paciente> pacientes = Arrays.asList(
+                new Paciente(2L, "98765432109", "Paciente 2", null),
+                new Paciente(1L, "12345678901", "Paciente 1", null)
+        );
+        when(pacienteRepository.listPacientesComConsultasFuturas(sort)).thenReturn(pacientes);
+
+        List<Paciente> result = pacienteService.listarPacientes(orderBy, direction);
+
+        assertEquals(pacientes.size(), result.size());
+        assertEquals(pacientes.get(0).getNome(), result.get(0).getNome());
+        assertEquals(pacientes.get(1).getNome(), result.get(1).getNome());
+
+        verify(listarPacienteParamsValidation, times(1)).validateParameters(orderBy);
+        verify(pacienteRepository, times(1)).listPacientesComConsultasFuturas(sort);
+    }
+
+    @Test
+    @DisplayName("Deve chamar a validação de parametros")
+    void deveChamarValidacaoDeParametros() {
+        String orderBy = "nome";
+        String direction = "desc";
+        Sort sort = Sort.by(Sort.Direction.DESC, orderBy);
+
+        List<Paciente> pacientes = Arrays.asList(
+                new Paciente(2L, "98765432109", "Paciente 2", null),
+                new Paciente(1L, "12345678901", "Paciente 1", null)
+        );
+        when(pacienteRepository.listPacientesComConsultasFuturas(sort)).thenReturn(pacientes);
+
+        pacienteService.listarPacientes(orderBy, direction);
+
+        verify(listarPacienteParamsValidation, times(1)).validateParameters(orderBy);
+    }
 }

--- a/src/test/java/com/devluizfcneto/sistemaodontologico/paciente/PacienteServiceRemoverTest.java
+++ b/src/test/java/com/devluizfcneto/sistemaodontologico/paciente/PacienteServiceRemoverTest.java
@@ -4,7 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doNothing;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -15,8 +18,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.devluizfcneto.sistemaodontologico.entities.Paciente;
+import com.devluizfcneto.sistemaodontologico.entities.Consulta;
 import com.devluizfcneto.sistemaodontologico.errors.PacienteNotFoundException;
 import com.devluizfcneto.sistemaodontologico.repositories.PacienteRepository;
+import com.devluizfcneto.sistemaodontologico.repositories.ConsultaRepository;
 import com.devluizfcneto.sistemaodontologico.services.impl.PacienteServiceImpl;
 
 // JUnit versão 5
@@ -25,6 +30,9 @@ public class PacienteServiceRemoverTest {
 
 	@Mock
 	private PacienteRepository pacienteRepository;
+
+	@Mock
+	private ConsultaRepository consultaRepository;
 	
 	@InjectMocks
 	private PacienteServiceImpl pacienteService;
@@ -35,30 +43,35 @@ public class PacienteServiceRemoverTest {
 //        MockitoAnnotations.openMocks(this);
 //    }
 
-	
+
 	@Test
 	@DisplayName("Testando remover paciente quando id existir")
 	public void deveRemoverPacienteQuandoIdExistir() {
-	    Long id = 1L;
-	    Paciente paciente = new Paciente();
-	    paciente.setId(id);
-	    Optional<Paciente> pacienteExistente = Optional.of(paciente);
-	
-	    when(pacienteRepository.findById(id)).thenReturn(pacienteExistente);
-	    pacienteService.remover(id);
-	
-	    verify(pacienteRepository, times(1)).delete(paciente);
+		Long id = 1L;
+		Paciente paciente = new Paciente();
+		paciente.setId(id);
+		List<Consulta> consultas = new ArrayList<>();
+		paciente.setConsultas(consultas);
+
+		Optional<Paciente> pacienteExistente = Optional.of(paciente);
+
+		when(pacienteRepository.findByIdWithConsultas(id)).thenReturn(pacienteExistente);
+		doNothing().when(consultaRepository).deleteAll(consultas);
+		pacienteService.remover(id);
+
+		verify(consultaRepository, times(1)).deleteAll(consultas);
+		verify(pacienteRepository, times(1)).delete(paciente);
 	}
-	
+
 	@Test
 	@DisplayName("Deve lançar exceção quando id não existir")
 	public void deveLancarExcecaoQuandoIdNaoExistir() {
-	    Long id = 1L;
-	    Optional<Paciente> pacienteExistente = Optional.empty();
-	
-	    when(pacienteRepository.findById(id)).thenReturn(pacienteExistente);
-	
-	    assertThrows(PacienteNotFoundException.class, () -> pacienteService.remover(id));
+		Long id = 1L;
+		Optional<Paciente> pacienteExistente = Optional.empty();
+
+		when(pacienteRepository.findByIdWithConsultas(id)).thenReturn(pacienteExistente);
+
+		assertThrows(PacienteNotFoundException.class, () -> pacienteService.remover(id));
 	}
 	
 }


### PR DESCRIPTION
Ajustada remoção de paciente, antes de remove-lo é necessario remover também as consultas associadas à ele. 
Solução sem utilizar o Cascade com orphanRemoval = true